### PR TITLE
Clarify storage key comments and add hatched fish list key

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,7 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// Key for storing fish in local storage
+// Key for storing the current fish in local storage
 const CURRENT_FISH_KEY = 'current_fish';
+
+// Key for storing the list of hatched fish
+const FISH_LIST_KEY = 'fish_list';
 
 export async function setCurrentFish(type: string) {
   await AsyncStorage.setItem(CURRENT_FISH_KEY, type);
@@ -22,7 +25,7 @@ export type Fish = {
  */
 export async function getFish(): Promise<Fish[]> {
   try {
-    const json = await AsyncStorage.getItem(CURRENT_FISH_KEY);
+    const json = await AsyncStorage.getItem(FISH_LIST_KEY);
     return json ? JSON.parse(json) : [];
   } catch (e) {
     console.error('Failed to load fish:', e);
@@ -45,7 +48,7 @@ export async function addFish(type: string): Promise<Fish> {
 
   console.log('Saving fish list:', existing); // 👈 DEBUG
 
-  await AsyncStorage.setItem(CURRENT_FISH_KEY, JSON.stringify(existing));
+  await AsyncStorage.setItem(FISH_LIST_KEY, JSON.stringify(existing));
 
   return fish;
 }
@@ -55,7 +58,7 @@ export async function addFish(type: string): Promise<Fish> {
  */
 export async function clearFish() {
   try {
-    await AsyncStorage.removeItem(CURRENT_FISH_KEY);
+    await AsyncStorage.removeItem(FISH_LIST_KEY);
     console.log('All fish cleared.');
   } catch (e) {
     console.error('Failed to clear fish:', e);


### PR DESCRIPTION
## Summary
- Clarify comment for `CURRENT_FISH_KEY` to mention the current fish
- Add `FISH_LIST_KEY` with explanatory comment and use it for stored fish list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f35ecd280832483a8dfa8615f8ca2