### PR TITLE
Fix storage utilities and tests

### DIFF
--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -1,5 +1,13 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { addFish, getFish, setCurrentFish, getCurrentFish, clearFish } from './storage';
+import {
+  addFish,
+  getFish,
+  setCurrentFish,
+  getCurrentFish,
+  clearFish,
+  FISH_LIST_KEY,
+  CURRENT_FISH_KEY,
+} from './storage';
 
 jest.mock('@react-native-async-storage/async-storage', () => {
   let store: Record<string, string> = {};
@@ -18,9 +26,6 @@ jest.mock('@react-native-async-storage/async-storage', () => {
     }),
   };
 });
-
-const FISH_LIST_KEY = 'fish_list';
-const CURRENT_FISH_KEY = 'current_fish';
 
 describe('storage utils', () => {
   beforeEach(async () => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,16 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-
 // Keys for storing fish data in local storage
-
-const CURRENT_FISH_KEY = 'current_fish';
-const FISH_LIST_KEY = 'fish_list';
-
-// Key for storing the list of caught fish
-const FISH_LIST_KEY = 'fish_list';
-
-// Key for storing the list of hatched fish
-const FISH_LIST_KEY = 'fish_list';
+export const CURRENT_FISH_KEY = 'current_fish';
+export const FISH_LIST_KEY = 'fish_list';
 
 export async function setCurrentFish(type: string) {
   await AsyncStorage.setItem(CURRENT_FISH_KEY, type);
@@ -52,8 +44,6 @@ export async function addFish(type: string): Promise<Fish> {
   const existing = await getFish();
   existing.push(fish);
 
-  console.log('Saving fish list:', existing); // 👈 DEBUG
-
   await AsyncStorage.setItem(FISH_LIST_KEY, JSON.stringify(existing));
 
   return fish;
@@ -65,7 +55,6 @@ export async function addFish(type: string): Promise<Fish> {
 export async function clearFish() {
   try {
     await AsyncStorage.removeItem(FISH_LIST_KEY);
-    console.log('All fish cleared.');
   } catch (e) {
     console.error('Failed to clear fish:', e);
   }


### PR DESCRIPTION
## Summary
- export AsyncStorage keys and remove duplicate definitions
- clean up storage functions and remove debug logs
- update tests to import shared keys

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688f3a00aa248324a97dd5247d42603d