### PR TITLE
feat: add task completion cooldown

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,31 +1,54 @@
 import { useRouter } from 'expo-router';
-import React from 'react';
-import { Button, Text, View } from 'react-native';
-import { addFish, setCurrentFish } from '../../src/utils/storage';
+import React, { useEffect, useState } from 'react';
+import { Alert, Button, Text, View } from 'react-native';
+import {
+  addFish,
+  setCurrentFish,
+  getTaskCompletions,
+  setTaskCompleted,
+  isTaskOnCooldown,
+  TaskCompletions,
+} from '../../src/utils/storage';
 
 export default function TaskScreen() {
   const router = useRouter();
   const tasks = ['Walk', 'Read', 'Meditate', 'Journal', 'Digital Detox'];
   const fishTypes = ['🐠', '🐟', '🐡', '🦈', '🐬', '🐳', '🐋'];
+  const [completions, setCompletions] = useState<TaskCompletions>({});
 
-function getRandomFish() {
-  const index = Math.floor(Math.random() * fishTypes.length);
-  return { id: index, emoji: fishTypes[index] };
-}
+  useEffect(() => {
+    (async () => {
+      const data = await getTaskCompletions();
+      setCompletions(data);
+    })();
+  }, []);
 
-async function handleTaskComplete(task: string) {
-  const randomFish = getRandomFish();
-  console.log('Generated fish:', randomFish.emoji);
+  function getRandomFish() {
+    const index = Math.floor(Math.random() * fishTypes.length);
+    return { id: index, emoji: fishTypes[index] };
+  }
 
-  await addFish(randomFish.emoji);
-  await setCurrentFish(randomFish.emoji);
+  async function handleTaskComplete(task: string) {
+    if (isTaskOnCooldown(completions, task)) {
+      Alert.alert('Task already completed', 'Please try again tomorrow.');
+      return;
+    }
 
-  // Pass only the ID, not the emoji
-  router.push({ 
-    pathname: '/hatch', 
-    params: { fishId: randomFish.id.toString(), key: Date.now().toString() }
-  });
-}
+    await setTaskCompleted(task);
+    setCompletions({ ...completions, [task]: Date.now() });
+
+    const randomFish = getRandomFish();
+    console.log('Generated fish:', randomFish.emoji);
+
+    await addFish(randomFish.emoji);
+    await setCurrentFish(randomFish.emoji);
+
+    // Pass only the ID, not the emoji
+    router.push({
+      pathname: '/hatch',
+      params: { fishId: randomFish.id.toString(), key: Date.now().toString() }
+    });
+  }
 
 
   return (
@@ -33,13 +56,17 @@ async function handleTaskComplete(task: string) {
       <Text style={{ fontSize: 20, marginBottom: 20 }}>
         Complete a Task to Hatch an Egg 🐣
       </Text>
-      {tasks.map((task) => (
-        <Button
-          key={task}
-          title={task}
-          onPress={() => handleTaskComplete(task)}
-        />
-      ))}
+      {tasks.map((task) => {
+        const disabled = isTaskOnCooldown(completions, task);
+        return (
+          <Button
+            key={task}
+            title={disabled ? `${task} (Done)` : task}
+            onPress={() => handleTaskComplete(task)}
+            disabled={disabled}
+          />
+        );
+      })}
     </View>
   );
 }

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -7,6 +7,9 @@ import {
   clearFish,
   FISH_LIST_KEY,
   CURRENT_FISH_KEY,
+  setTaskCompleted,
+  getTaskCompletions,
+  TASK_COMPLETIONS_KEY,
 } from './storage';
 
 jest.mock('@react-native-async-storage/async-storage', () => {
@@ -57,5 +60,16 @@ describe('storage utils', () => {
     const list = await getFish();
     expect(list).toEqual([]);
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith(FISH_LIST_KEY);
+  });
+
+  it('setTaskCompleted records a timestamp and getTaskCompletions retrieves it', async () => {
+    await setTaskCompleted('Walk');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      TASK_COMPLETIONS_KEY,
+      expect.any(String)
+    );
+    const completions = await getTaskCompletions();
+    expect(completions.Walk).toBeDefined();
+    expect(typeof completions.Walk).toBe('number');
   });
 });


### PR DESCRIPTION
## Summary
- track task completions in AsyncStorage with timestamps and cooldown check
- disable tasks for 24 hours after completion
- test task completion storage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f56fc55208324a26df38d3f024ba4