### PR TITLE
Add fish rarity, names, and hatch metadata

### DIFF
--- a/app/(tabs)/aquarium.tsx
+++ b/app/(tabs)/aquarium.tsx
@@ -52,16 +52,17 @@ export default function AquariumScreen() {
         </View>
       ) : (
         animations.map((anim, index) => (
-          <Animated.Text
+          <Animated.View
             key={fish[index].id}
             style={{
               position: 'absolute',
-              fontSize: 40,
               transform: [{ translateX: anim.x }, { translateY: anim.y }],
+              alignItems: 'center',
             }}
           >
-            {fish[index].type}
-          </Animated.Text>
+            <Text style={{ fontSize: 40 }}>{fish[index].type}</Text>
+            <Text style={{ fontSize: 12 }}>{fish[index].name}</Text>
+          </Animated.View>
         ))
       )}
     </View>

--- a/app/(tabs)/hatch.tsx
+++ b/app/(tabs)/hatch.tsx
@@ -9,6 +9,18 @@ export default function HatchScreen() {
   const params = useLocalSearchParams();
   const fishId = params.fishId ? parseInt(params.fishId as string, 10) : null;
   const fish = fishId !== null ? fishTypes[fishId] : null;
+  const name = params.name as string | undefined;
+  const rarity = (params.rarity as string | undefined) ?? 'common';
+  const hatchedAt = params.hatchedAt ? new Date(parseInt(params.hatchedAt as string, 10)) : null;
+
+  const rarityStyles: Record<string, { color: string; scale: number }> = {
+    common: { color: '#000', scale: 1 },
+    rare: { color: '#2196F3', scale: 1.2 },
+    epic: { color: '#9C27B0', scale: 1.5 },
+    legendary: { color: '#FF9800', scale: 2 },
+  };
+
+  const rarityStyle = rarityStyles[rarity] ?? rarityStyles.common;
 
   const [showFish, setShowFish] = useState(false);
   const [fadeAnim] = useState(new Animated.Value(0));
@@ -44,9 +56,10 @@ export default function HatchScreen() {
           style={{
             fontSize: 50,
             opacity: fadeAnim,
+            color: rarityStyle.color,
             transform: [
               {
-                scale: fadeAnim.interpolate({ inputRange: [0, 1], outputRange: [0.3, 1] })
+                scale: fadeAnim.interpolate({ inputRange: [0, 1], outputRange: [0.3, rarityStyle.scale] })
               }
             ]
           }}
@@ -55,8 +68,12 @@ export default function HatchScreen() {
         </Animated.Text>
       )}
 
-      <Text style={{ fontSize: 20, marginTop: 20 }}>
-        {!showFish ? 'Egg is hatching...' : 'Your fish hatched!'}
+      <Text style={{ fontSize: 20, marginTop: 20, textAlign: 'center' }}>
+        {!showFish
+          ? 'Egg is hatching...'
+          : `Your ${rarity} fish ${name ?? ''} hatched on ${
+              hatchedAt ? hatchedAt.toLocaleString() : ''
+            }!`}
       </Text>
     </View>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -14,6 +14,7 @@ export default function TaskScreen() {
   const router = useRouter();
   const tasks = ['Walk', 'Read', 'Meditate', 'Journal', 'Digital Detox'];
   const fishTypes = ['🐠', '🐟', '🐡', '🦈', '🐬', '🐳', '🐋'];
+  const fishNames = ['Nemo', 'Dory', 'Bubbles', 'Finley', 'Coral', 'Gill', 'Splash'];
   const [completions, setCompletions] = useState<TaskCompletions>({});
 
   useEffect(() => {
@@ -28,6 +29,19 @@ export default function TaskScreen() {
     return { id: index, emoji: fishTypes[index] };
   }
 
+  function getRandomName() {
+    const index = Math.floor(Math.random() * fishNames.length);
+    return fishNames[index];
+  }
+
+  function getRandomRarity() {
+    const r = Math.random();
+    if (r < 0.6) return 'common';
+    if (r < 0.85) return 'rare';
+    if (r < 0.97) return 'epic';
+    return 'legendary';
+  }
+
   async function handleTaskComplete(task: string) {
     if (isTaskOnCooldown(completions, task)) {
       Alert.alert('Task already completed', 'Please try again tomorrow.');
@@ -38,15 +52,22 @@ export default function TaskScreen() {
     setCompletions({ ...completions, [task]: Date.now() });
 
     const randomFish = getRandomFish();
-    console.log('Generated fish:', randomFish.emoji);
+    const name = getRandomName();
+    const rarity = getRandomRarity();
+    console.log('Generated fish:', randomFish.emoji, name, rarity);
 
-    await addFish(randomFish.emoji);
+    const fishRecord = await addFish(randomFish.emoji, name, rarity);
     await setCurrentFish(randomFish.emoji);
 
-    // Pass only the ID, not the emoji
     router.push({
       pathname: '/hatch',
-      params: { fishId: randomFish.id.toString(), key: Date.now().toString() }
+      params: {
+        fishId: randomFish.id.toString(),
+        name,
+        rarity,
+        hatchedAt: fishRecord.timestamp.toString(),
+        key: Date.now().toString(),
+      }
     });
   }
 

--- a/app/hatch.tsx
+++ b/app/hatch.tsx
@@ -9,6 +9,18 @@ export default function HatchScreen() {
   const params = useLocalSearchParams();
   const fishId = params.fishId ? parseInt(params.fishId as string, 10) : null;
   const fish = fishId !== null ? fishTypes[fishId] : null;
+  const name = params.name as string | undefined;
+  const rarity = (params.rarity as string | undefined) ?? 'common';
+  const hatchedAt = params.hatchedAt ? new Date(parseInt(params.hatchedAt as string, 10)) : null;
+
+  const rarityStyles: Record<string, { color: string; scale: number }> = {
+    common: { color: '#000', scale: 1 },
+    rare: { color: '#2196F3', scale: 1.2 },
+    epic: { color: '#9C27B0', scale: 1.5 },
+    legendary: { color: '#FF9800', scale: 2 },
+  };
+
+  const rarityStyle = rarityStyles[rarity] ?? rarityStyles.common;
 
   const [showFish, setShowFish] = useState(false);
   const [fadeAnim] = useState(new Animated.Value(0));
@@ -44,9 +56,10 @@ export default function HatchScreen() {
           style={{
             fontSize: 50,
             opacity: fadeAnim,
+            color: rarityStyle.color,
             transform: [
               {
-                scale: fadeAnim.interpolate({ inputRange: [0, 1], outputRange: [0.3, 1] })
+                scale: fadeAnim.interpolate({ inputRange: [0, 1], outputRange: [0.3, rarityStyle.scale] })
               }
             ]
           }}
@@ -55,8 +68,12 @@ export default function HatchScreen() {
         </Animated.Text>
       )}
 
-      <Text style={{ fontSize: 20, marginTop: 20 }}>
-        {!showFish ? 'Egg is hatching...' : 'Your fish hatched!'}
+      <Text style={{ fontSize: 20, marginTop: 20, textAlign: 'center' }}>
+        {!showFish
+          ? 'Egg is hatching...'
+          : `Your ${rarity} fish ${name ?? ''} hatched on ${
+              hatchedAt ? hatchedAt.toLocaleString() : ''
+            }!`}
       </Text>
     </View>
   );

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -37,12 +37,16 @@ describe('storage utils', () => {
   });
 
   it('addFish adds a fish and getFish retrieves the list', async () => {
-    const fish = await addFish('salmon');
+    const fish = await addFish('salmon', 'Nemo', 'common');
     expect(fish.type).toBe('salmon');
+    expect(fish.name).toBe('Nemo');
+    expect(fish.rarity).toBe('common');
 
     const list = await getFish();
     expect(list).toHaveLength(1);
     expect(list[0].type).toBe('salmon');
+    expect(list[0].name).toBe('Nemo');
+    expect(list[0].rarity).toBe('common');
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(FISH_LIST_KEY, expect.any(String));
   });
 
@@ -55,7 +59,7 @@ describe('storage utils', () => {
   });
 
   it('clearFish empties stored fish data', async () => {
-    await addFish('cod');
+    await addFish('cod', 'Bubbles', 'rare');
     await clearFish();
     const list = await getFish();
     expect(list).toEqual([]);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,9 +13,13 @@ export async function getCurrentFish(): Promise<string | null> {
   return await AsyncStorage.getItem(CURRENT_FISH_KEY);
 }
 
+export type Rarity = 'common' | 'rare' | 'epic' | 'legendary';
+
 export type Fish = {
   id: string;
   type: string;
+  name: string;
+  rarity: Rarity;
   timestamp: number;
 };
 
@@ -35,10 +39,12 @@ export async function getFish(): Promise<Fish[]> {
 /**
  * Add a new fish and save it to storage
  */
-export async function addFish(type: string): Promise<Fish> {
+export async function addFish(type: string, name: string, rarity: Rarity): Promise<Fish> {
   const fish: Fish = {
     id: Date.now().toString(),
     type,
+    name,
+    rarity,
     timestamp: Date.now(),
   };
 


### PR DESCRIPTION
## Summary
- assign random names and rarity when hatching a fish
- show name, rarity, and hatch date with rarity-based animation
- display fish names in the aquarium

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f5903490883249f5c1b22136a1220