### PR TITLE
Make addFish parameters optional

### DIFF
--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -50,6 +50,13 @@ describe('storage utils', () => {
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(FISH_LIST_KEY, expect.any(String));
   });
 
+  it('addFish supplies defaults when name and rarity are omitted', async () => {
+    const fish = await addFish('trout');
+    expect(fish.type).toBe('trout');
+    expect(fish.name).toBe('Unnamed');
+    expect(fish.rarity).toBe('common');
+  });
+
   it('setCurrentFish and getCurrentFish handle the current fish', async () => {
     await setCurrentFish('tuna');
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(CURRENT_FISH_KEY, 'tuna');

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -37,9 +37,17 @@ export async function getFish(): Promise<Fish[]> {
 }
 
 /**
- * Add a new fish and save it to storage
+ * Add a new fish and save it to storage.
+ *
+ * The name and rarity arguments are optional so callers that only
+ * provide the fish type/emoji continue to work. When omitted, a
+ * sensible default is used for each property.
  */
-export async function addFish(type: string, name: string, rarity: Rarity): Promise<Fish> {
+export async function addFish(
+  type: string,
+  name = 'Unnamed',
+  rarity: Rarity = 'common'
+): Promise<Fish> {
   const fish: Fish = {
     id: Date.now().toString(),
     type,


### PR DESCRIPTION
## Summary
- allow `addFish` to be called with only the fish emoji by providing default name and rarity values
- cover new behaviour with a unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f6fb03bec8324816a6a1a09570935