### PR TITLE
Reduce task cooldown to 20 seconds

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -44,7 +44,7 @@ export default function TaskScreen() {
 
   async function handleTaskComplete(task: string) {
     if (isTaskOnCooldown(completions, task)) {
-      Alert.alert('Task already completed', 'Please try again tomorrow.');
+      Alert.alert('Task already completed', 'Please try again in 20 seconds.');
       return;
     }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 export const CURRENT_FISH_KEY = 'current_fish';
 export const FISH_LIST_KEY = 'fish_list';
 export const TASK_COMPLETIONS_KEY = 'task_completions';
+export const TASK_COOLDOWN_MS = 20 * 1000;
 
 export async function setCurrentFish(type: string) {
   await AsyncStorage.setItem(CURRENT_FISH_KEY, type);
@@ -108,7 +109,7 @@ export async function setTaskCompleted(task: string): Promise<void> {
 export function isTaskOnCooldown(
   completions: TaskCompletions,
   task: string,
-  cooldownMs = 24 * 60 * 60 * 1000
+  cooldownMs = TASK_COOLDOWN_MS
 ): boolean {
   const last = completions[task];
   return last ? Date.now() - last < cooldownMs : false;


### PR DESCRIPTION
## Summary
- add constant for task cooldown and set to 20 seconds
- update alert message to reflect shorter cooldown

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f71f2eed883249a29b152b574c43f