### PR TITLE
feat: add research-driven daily challenges

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,76 +1,30 @@
 import { useRouter } from 'expo-router';
-import React, { useEffect, useState } from 'react';
-import { Alert, Button, Text, View } from 'react-native';
-import {
-  addFish,
-  setCurrentFish,
-  getTaskCompletions,
-  setTaskCompleted,
-  isTaskOnCooldown,
-  TaskCompletions,
-} from '../../src/utils/storage';
+import React, { useCallback, useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { getTaskCompletions, isTaskOnCooldown, TaskCompletions } from '../../src/utils/storage';
+
+const tasks = [
+  { key: 'Walk', label: 'Walk in Nature', route: 'walk' },
+  { key: 'Read', label: 'Reading', route: 'read' },
+  { key: 'Journal', label: 'Journaling', route: 'journal' },
+  { key: 'Meditate', label: 'Mindfulness Meditation', route: 'meditate' },
+  { key: 'Digital Detox', label: 'Digital Detox', route: 'digital-detox' },
+  { key: 'Boredom Challenge', label: 'Boredom Challenge', route: 'boredom' },
+];
 
 export default function TaskScreen() {
   const router = useRouter();
-  const tasks = ['Walk', 'Read', 'Meditate', 'Journal', 'Digital Detox'];
-  const fishTypes = ['🐠', '🐟', '🐡', '🦈', '🐬', '🐳', '🐋'];
-  const fishNames = ['Nemo', 'Dory', 'Bubbles', 'Finley', 'Coral', 'Gill', 'Splash'];
   const [completions, setCompletions] = useState<TaskCompletions>({});
 
-  useEffect(() => {
-    (async () => {
-      const data = await getTaskCompletions();
-      setCompletions(data);
-    })();
-  }, []);
-
-  function getRandomFish() {
-    const index = Math.floor(Math.random() * fishTypes.length);
-    return { id: index, emoji: fishTypes[index] };
-  }
-
-  function getRandomName() {
-    const index = Math.floor(Math.random() * fishNames.length);
-    return fishNames[index];
-  }
-
-  function getRandomRarity() {
-    const r = Math.random();
-    if (r < 0.6) return 'common';
-    if (r < 0.85) return 'rare';
-    if (r < 0.97) return 'epic';
-    return 'legendary';
-  }
-
-  async function handleTaskComplete(task: string) {
-    if (isTaskOnCooldown(completions, task)) {
-      Alert.alert('Task already completed', 'Please try again in 20 seconds.');
-      return;
-    }
-
-    await setTaskCompleted(task);
-    setCompletions({ ...completions, [task]: Date.now() });
-
-    const randomFish = getRandomFish();
-    const name = getRandomName();
-    const rarity = getRandomRarity();
-    console.log('Generated fish:', randomFish.emoji, name, rarity);
-
-    const fishRecord = await addFish(randomFish.emoji, name, rarity);
-    await setCurrentFish(randomFish.emoji);
-
-    router.push({
-      pathname: '/hatch',
-      params: {
-        fishId: randomFish.id.toString(),
-        name,
-        rarity,
-        hatchedAt: fishRecord.timestamp.toString(),
-        key: Date.now().toString(),
-      }
-    });
-  }
-
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        const data = await getTaskCompletions();
+        setCompletions(data);
+      })();
+    }, [])
+  );
 
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -78,12 +32,12 @@ export default function TaskScreen() {
         Complete a Task to Hatch an Egg 🐣
       </Text>
       {tasks.map((task) => {
-        const disabled = isTaskOnCooldown(completions, task);
+        const disabled = isTaskOnCooldown(completions, task.key);
         return (
           <Button
-            key={task}
-            title={disabled ? `${task} (Done)` : task}
-            onPress={() => handleTaskComplete(task)}
+            key={task.key}
+            title={disabled ? `${task.label} (Done)` : task.label}
+            onPress={() => router.push(`/tasks/${task.route}`)}
             disabled={disabled}
           />
         );

--- a/app/tasks/_layout.tsx
+++ b/app/tasks/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function TaskLayout() {
+  return <Stack />;
+}

--- a/app/tasks/boredom.tsx
+++ b/app/tasks/boredom.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, TextInput } from 'react-native';
+import { useRouter } from 'expo-router';
+import { completeTask, formatTime } from '../../src/utils/taskHelpers';
+
+const durations = [10, 15];
+
+export default function BoredomScreen() {
+  const router = useRouter();
+  const [duration, setDuration] = useState(10);
+  const [seconds, setSeconds] = useState(duration * 60);
+  const [running, setRunning] = useState(false);
+  const [reflect, setReflect] = useState('');
+  const [finished, setFinished] = useState(false);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+    if (running && seconds > 0) {
+      timer = setTimeout(() => setSeconds((s) => s - 1), 1000);
+    } else if (running && seconds === 0) {
+      setRunning(false);
+      setFinished(true);
+    }
+    return () => clearTimeout(timer);
+  }, [running, seconds]);
+
+  const start = () => {
+    setSeconds(duration * 60);
+    setRunning(true);
+  };
+
+  const complete = () => {
+    completeTask('Boredom Challenge', router);
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      {!finished ? (
+        <>
+          <Text style={{ marginBottom: 20 }}>
+            Spend 10–15 minutes with no stimulation. Let your mind wander.
+          </Text>
+          {!running && (
+            <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginBottom: 20 }}>
+              {durations.map((d) => (
+                <Button key={d} title={`${d}m`} onPress={() => setDuration(d)} />
+              ))}
+            </View>
+          )}
+          {running ? (
+            <Text style={{ fontSize: 32, textAlign: 'center' }}>{formatTime(seconds)}</Text>
+          ) : (
+            <Button title="Start" onPress={start} />
+          )}
+        </>
+      ) : (
+        <>
+          <Text style={{ marginBottom: 10 }}>
+            Reflect on any ideas or insights that arose:
+          </Text>
+          <TextInput
+            value={reflect}
+            onChangeText={setReflect}
+            multiline
+            style={{ borderWidth: 1, padding: 8, height: 200, marginBottom: 20, textAlignVertical: 'top' }}
+          />
+          <Button title="Complete" onPress={complete} />
+        </>
+      )}
+    </View>
+  );
+}

--- a/app/tasks/digital-detox.tsx
+++ b/app/tasks/digital-detox.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { useRouter } from 'expo-router';
+import { completeTask, formatTime } from '../../src/utils/taskHelpers';
+
+const options = [15, 30, 60];
+
+export default function DigitalDetoxScreen() {
+  const router = useRouter();
+  const [duration, setDuration] = useState(15);
+  const [seconds, setSeconds] = useState(duration * 60);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+    if (running && seconds > 0) {
+      timer = setTimeout(() => setSeconds((s) => s - 1), 1000);
+    } else if (running && seconds === 0) {
+      completeTask('Digital Detox', router);
+    }
+    return () => clearTimeout(timer);
+  }, [running, seconds]);
+
+  function start() {
+    setSeconds(duration * 60);
+    setRunning(true);
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ marginBottom: 10 }}>
+        Step away from your device for a while. Choose a duration and stay
+        on this screen until the timer ends.
+      </Text>
+      {!running && (
+        <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginBottom: 20 }}>
+          {options.map((o) => (
+            <Button key={o} title={`${o}m`} onPress={() => setDuration(o)} />
+          ))}
+        </View>
+      )}
+      {running ? (
+        <Text style={{ fontSize: 32, textAlign: 'center' }}>{formatTime(seconds)}</Text>
+      ) : (
+        <Button title="Start Detox" onPress={start} />
+      )}
+    </View>
+  );
+}

--- a/app/tasks/journal.tsx
+++ b/app/tasks/journal.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { View, Text, Button, TextInput } from 'react-native';
+import { useRouter } from 'expo-router';
+import { completeTask } from '../../src/utils/taskHelpers';
+
+const prompts = [
+  'What are you grateful for today?',
+  'Describe a recent emotion and what triggered it.',
+  'Write about something that challenged you this week.',
+];
+
+export default function JournalScreen() {
+  const router = useRouter();
+  const [prompt, setPrompt] = useState(prompts[0]);
+  const [entry, setEntry] = useState('');
+
+  function newPrompt() {
+    const index = Math.floor(Math.random() * prompts.length);
+    setPrompt(prompts[index]);
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ marginBottom: 10 }}>{prompt}</Text>
+      <Button title="New Prompt" onPress={newPrompt} />
+      <TextInput
+        value={entry}
+        onChangeText={setEntry}
+        placeholder="Write freely..."
+        multiline
+        style={{
+          borderWidth: 1,
+          padding: 8,
+          height: 200,
+          marginVertical: 20,
+          textAlignVertical: 'top',
+        }}
+      />
+      <Button title="Complete" onPress={() => completeTask('Journal', router)} />
+    </View>
+  );
+}

--- a/app/tasks/meditate.tsx
+++ b/app/tasks/meditate.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { useRouter } from 'expo-router';
+import { completeTask, formatTime } from '../../src/utils/taskHelpers';
+
+const techniques: Record<string, string> = {
+  'Breath Focus': 'Focus gently on the breath and return when distracted.',
+  'Body Scan': 'Move attention slowly through your body from head to toe.',
+  'Loving Kindness': 'Silently send kind wishes to yourself and others.',
+};
+
+export default function MeditateScreen() {
+  const router = useRouter();
+  const [technique, setTechnique] = useState(Object.keys(techniques)[0]);
+  const [seconds, setSeconds] = useState(8 * 60);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+    if (running && seconds > 0) {
+      timer = setTimeout(() => setSeconds((s) => s - 1), 1000);
+    } else if (running && seconds === 0) {
+      completeTask('Meditate', router);
+    }
+    return () => clearTimeout(timer);
+  }, [running, seconds]);
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ marginBottom: 10 }}>
+        Even an 8-minute meditation can boost short-term memory. Select a
+        technique and begin.
+      </Text>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginBottom: 10 }}>
+        {Object.keys(techniques).map((k) => (
+          <Button key={k} title={k} onPress={() => setTechnique(k)} />
+        ))}
+      </View>
+      <Text style={{ marginBottom: 20 }}>{techniques[technique]}</Text>
+      {running ? (
+        <Text style={{ fontSize: 32, textAlign: 'center' }}>{formatTime(seconds)}</Text>
+      ) : (
+        <Button
+          title="Start 8-minute Meditation"
+          onPress={() => setRunning(true)}
+        />
+      )}
+    </View>
+  );
+}

--- a/app/tasks/read.tsx
+++ b/app/tasks/read.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+import { useRouter } from 'expo-router';
+import { completeTask, formatTime } from '../../src/utils/taskHelpers';
+
+export default function ReadScreen() {
+  const router = useRouter();
+  const [material, setMaterial] = useState('');
+  const [mode, setMode] = useState<'minutes' | 'pages'>('minutes');
+  const [goal, setGoal] = useState('20');
+  const [seconds, setSeconds] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+    if (running && seconds > 0) {
+      timer = setTimeout(() => setSeconds((s) => s - 1), 1000);
+    } else if (running && seconds === 0 && mode === 'minutes') {
+      completeTask('Read', router);
+    }
+    return () => clearTimeout(timer);
+  }, [running, seconds, mode]);
+
+  function start() {
+    if (mode === 'minutes') {
+      const mins = parseInt(goal, 10) || 20;
+      setSeconds(mins * 60);
+      setRunning(true);
+    } else {
+      completeTask('Read', router);
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text>
+        Reading 10 pages (about 20–30 minutes) improves memory and reduces
+        stress. Pick something you'd like to read.
+      </Text>
+      <TextInput
+        placeholder="Material"
+        value={material}
+        onChangeText={setMaterial}
+        style={{ borderWidth: 1, padding: 8, marginVertical: 10 }}
+      />
+      <Button
+        title={`Goal: ${mode}`}
+        onPress={() => setMode(mode === 'minutes' ? 'pages' : 'minutes')}
+      />
+      <TextInput
+        placeholder={mode === 'minutes' ? 'Minutes' : 'Pages'}
+        keyboardType="number-pad"
+        value={goal}
+        onChangeText={setGoal}
+        style={{ borderWidth: 1, padding: 8, marginVertical: 10 }}
+      />
+      {running && mode === 'minutes' ? (
+        <Text style={{ fontSize: 32, textAlign: 'center' }}>{formatTime(seconds)}</Text>
+      ) : (
+        <Button
+          title={mode === 'minutes' ? 'Start Reading' : 'Complete'}
+          onPress={start}
+        />
+      )}
+    </View>
+  );
+}

--- a/app/tasks/walk.tsx
+++ b/app/tasks/walk.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { useRouter } from 'expo-router';
+import { completeTask, formatTime } from '../../src/utils/taskHelpers';
+
+export default function WalkScreen() {
+  const router = useRouter();
+  const [seconds, setSeconds] = useState(15 * 60);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+    if (running && seconds > 0) {
+      timer = setTimeout(() => setSeconds((s) => s - 1), 1000);
+    } else if (running && seconds === 0) {
+      completeTask('Walk', router);
+    }
+    return () => clearTimeout(timer);
+  }, [running, seconds]);
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <Text style={{ marginBottom: 20 }}>
+        Take a 15-minute walk in a natural environment. Notice the sights,
+        sounds and smells around you.
+      </Text>
+      {running ? (
+        <Text style={{ fontSize: 32, textAlign: 'center' }}>{formatTime(seconds)}</Text>
+      ) : (
+        <Button title="Start Walk" onPress={() => setRunning(true)} />
+      )}
+    </View>
+  );
+}

--- a/src/utils/taskHelpers.ts
+++ b/src/utils/taskHelpers.ts
@@ -1,0 +1,50 @@
+import { addFish, setCurrentFish, setTaskCompleted } from './storage';
+import { Router } from 'expo-router';
+
+const fishTypes = ['🐠', '🐟', '🐡', '🦈', '🐬', '🐳', '🐋'];
+const fishNames = ['Nemo', 'Dory', 'Bubbles', 'Finley', 'Coral', 'Gill', 'Splash'];
+
+function getRandomFish() {
+  const index = Math.floor(Math.random() * fishTypes.length);
+  return { id: index, emoji: fishTypes[index] };
+}
+
+function getRandomName() {
+  const index = Math.floor(Math.random() * fishNames.length);
+  return fishNames[index];
+}
+
+function getRandomRarity(): 'common' | 'rare' | 'epic' | 'legendary' {
+  const r = Math.random();
+  if (r < 0.6) return 'common';
+  if (r < 0.85) return 'rare';
+  if (r < 0.97) return 'epic';
+  return 'legendary';
+}
+
+export async function completeTask(task: string, router: Router) {
+  await setTaskCompleted(task);
+  const randomFish = getRandomFish();
+  const name = getRandomName();
+  const rarity = getRandomRarity();
+  const fishRecord = await addFish(randomFish.emoji, name, rarity);
+  await setCurrentFish(randomFish.emoji);
+  router.push({
+    pathname: '/hatch',
+    params: {
+      fishId: randomFish.id.toString(),
+      name,
+      rarity,
+      hatchedAt: fishRecord.timestamp.toString(),
+      key: Date.now().toString(),
+    },
+  });
+}
+
+export function formatTime(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}


### PR DESCRIPTION
## Summary
- expand task list to cover walking in nature, reading, journaling, meditation, digital detox and boredom exposure
- add dedicated challenge screens with timers, prompts, and completion flow that awards fish
- refresh task cooldowns when returning to the home screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689242833ee0832488bcf84cba696b6a