### PR TITLE
feat: add onboarding flow

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,21 +1,35 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Provider as PaperProvider } from 'react-native-paper';
 import 'react-native-reanimated';
+import { useEffect, useState } from 'react';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { hasCompletedOnboarding } from '@/src/utils/storage';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const router = useRouter();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+  const [ready, setReady] = useState(false);
 
-  if (!loaded) {
+  useEffect(() => {
+    (async () => {
+      const done = await hasCompletedOnboarding();
+      if (!done) {
+        router.replace('/onboarding');
+      }
+      setReady(true);
+    })();
+  }, [router]);
+
+  if (!loaded || !ready) {
     // Async font loading only occurs in development.
     return null;
   }
@@ -26,6 +40,7 @@ export default function RootLayout() {
         <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="onboarding" options={{ headerShown: false }} />
             <Stack.Screen name="+not-found" />
           </Stack>
           <StatusBar style="auto" />

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function OnboardingLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/onboarding/focus.tsx
+++ b/app/onboarding/focus.tsx
@@ -1,0 +1,55 @@
+import { useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { Checkbox } from 'react-native-paper';
+
+const options = [
+  {
+    key: 'stress',
+    title: 'Stress reduction',
+    description: 'Nature walks improve attention and mood.',
+  },
+  {
+    key: 'focus',
+    title: 'Focus',
+    description: 'Journaling reduces mental distress.',
+  },
+  {
+    key: 'creativity',
+    title: 'Creativity',
+    description: 'Reading can spark new ideas and insights.',
+  },
+];
+
+export default function FocusScreen() {
+  const router = useRouter();
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+
+  const toggle = (key: string) => {
+    setSelected((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 20, justifyContent: 'center' }}>
+      <Text style={{ fontSize: 28, textAlign: 'center', marginBottom: 20 }}>
+        Choose your focus
+      </Text>
+      {options.map((opt) => (
+        <View
+          key={opt.key}
+          style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 15 }}
+        >
+          <Checkbox
+            status={selected[opt.key] ? 'checked' : 'unchecked'}
+            onPress={() => toggle(opt.key)}
+          />
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontWeight: 'bold' }}>{opt.title}</Text>
+            <Text>{opt.description}</Text>
+          </View>
+        </View>
+      ))}
+      <Button title="Next" onPress={() => router.push('/onboarding/reminders')} />
+    </View>
+  );
+}

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'expo-router';
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+
+export default function WelcomeScreen() {
+  const router = useRouter();
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
+      <Text style={{ fontSize: 32, marginBottom: 20, textAlign: 'center' }}>
+        Welcome to MindPond
+      </Text>
+      <Text style={{ fontSize: 16, marginBottom: 40, textAlign: 'center' }}>
+        Build mental capacity through evidence-based micro-activities.
+      </Text>
+      <Text style={{ fontSize: 64, marginBottom: 40 }}>🐟</Text>
+      <Button title="Next" onPress={() => router.push('/onboarding/focus')} />
+    </View>
+  );
+}

--- a/app/onboarding/reminders.tsx
+++ b/app/onboarding/reminders.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { View, Text, Button, Switch } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { scheduleDailyReminder } from '@/src/utils/reminders';
+import { setOnboardingComplete } from '@/src/utils/storage';
+
+export default function ReminderScreen() {
+  const router = useRouter();
+  const [enabled, setEnabled] = useState(true);
+  const [time, setTime] = useState(() => {
+    const d = new Date();
+    d.setHours(9, 0, 0, 0);
+    return d;
+    // default 9AM
+  });
+
+  const onFinish = async () => {
+    if (enabled) {
+      await scheduleDailyReminder(time);
+    }
+    await setOnboardingComplete();
+    router.replace('/');
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
+      <Text style={{ fontSize: 28, marginBottom: 20 }}>Set up reminders</Text>
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 20 }}>
+        <Text style={{ marginRight: 10 }}>Daily reminder</Text>
+        <Switch value={enabled} onValueChange={setEnabled} />
+      </View>
+      {enabled && (
+        <DateTimePicker
+          value={time}
+          mode="time"
+          onChange={(event, date) => {
+            if (date) setTime(date);
+          }}
+        />
+      )}
+      <Button title="Finish" onPress={onFinish} />
+    </View>
+  );
+}

--- a/src/utils/reminders.ts
+++ b/src/utils/reminders.ts
@@ -14,3 +14,22 @@ export async function scheduleTaskReminder(task: string, date: Date) {
     trigger: date,
   });
 }
+
+export async function scheduleDailyReminder(time: Date) {
+  const { status } = await Notifications.requestPermissionsAsync();
+  if (status !== 'granted') {
+    return;
+  }
+
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'MindPond Reminder',
+      body: 'Time for your MindPond activity',
+    },
+    trigger: {
+      hour: time.getHours(),
+      minute: time.getMinutes(),
+      repeats: true,
+    },
+  });
+}

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -13,6 +13,9 @@ import {
   TASK_COMPLETIONS_KEY,
   getStreak,
   FISH_LIFESPAN_MS,
+  setOnboardingComplete,
+  hasCompletedOnboarding,
+  ONBOARDING_KEY,
 } from './storage';
 
 jest.mock('@react-native-async-storage/async-storage', () => {
@@ -111,5 +114,12 @@ describe('storage utils', () => {
     expect(await getStreak()).toBe(2);
 
     jest.useRealTimers();
+  });
+
+  it('tracks onboarding completion', async () => {
+    expect(await hasCompletedOnboarding()).toBe(false);
+    await setOnboardingComplete();
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(ONBOARDING_KEY, 'true');
+    expect(await hasCompletedOnboarding()).toBe(true);
   });
 });

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -7,6 +7,7 @@ export const TASK_COMPLETIONS_KEY = 'task_completions';
 export const TASK_COOLDOWN_MS = 20 * 1000;
 export const STREAK_COUNT_KEY = 'streak_count';
 export const STREAK_LAST_DATE_KEY = 'streak_last_date';
+export const ONBOARDING_KEY = 'onboarding_complete';
 
 // How long each fish rarity should live, in milliseconds
 export const FISH_LIFESPAN_MS: Record<Rarity, number> = {
@@ -188,4 +189,13 @@ export function isTaskOnCooldown(
 ): boolean {
   const last = completions[task];
   return last ? Date.now() - last < cooldownMs : false;
+}
+
+export async function setOnboardingComplete(): Promise<void> {
+  await AsyncStorage.setItem(ONBOARDING_KEY, 'true');
+}
+
+export async function hasCompletedOnboarding(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(ONBOARDING_KEY);
+  return value === 'true';
 }


### PR DESCRIPTION
## Summary
- add onboarding screens for welcome, focus selection, and reminders
- track onboarding completion and schedule daily reminders
- show onboarding only once before navigating to main activities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689261703d248324a17f195def7098bc