### PR TITLE
Initialize gesture handler before other imports

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,11 @@
+import 'react-native-gesture-handler';
+import 'react-native-reanimated';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import 'react-native-gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Provider as PaperProvider } from 'react-native-paper';
-import 'react-native-reanimated';
 import { useEffect, useState } from 'react';
 
 import { useColorScheme } from '@/hooks/useColorScheme';


### PR DESCRIPTION
## Summary
- ensure gesture handler and reanimated are imported before other modules to avoid blank first screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689264cbb3148324aaab9c6617b824f4