### PR TITLE
Show loading indicator during app startup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { useEffect, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { hasCompletedOnboarding } from '@/src/utils/storage';
@@ -31,7 +32,12 @@ export default function RootLayout() {
 
   if (!loaded || !ready) {
     // Async font loading only occurs in development.
-    return null;
+    // Show a loading indicator instead of a blank screen.
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator />
+      </View>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- show a loading indicator instead of returning null while fonts and onboarding state load

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6895daa6b72c8324aafbb76f8c585281