### PR TITLE
fix: handle onboarding load errors

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,13 +21,28 @@ export default function RootLayout() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    (async () => {
-      const done = await hasCompletedOnboarding();
-      if (!done) {
-        router.replace('/onboarding');
+    let cancelled = false;
+
+    const prepare = async () => {
+      try {
+        const done = await hasCompletedOnboarding();
+        if (!done) {
+          router.replace('/onboarding');
+        }
+      } catch (e) {
+        console.error('Failed to determine onboarding status', e);
+      } finally {
+        if (!cancelled) {
+          setReady(true);
+        }
       }
-      setReady(true);
-    })();
+    };
+
+    prepare();
+
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   if (!loaded || !ready) {


### PR DESCRIPTION
## Summary
- avoid infinite loading screen by handling onboarding storage errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895df9af5008324813e2f71f9d77203